### PR TITLE
Call redis service by its full domain name

### DIFF
--- a/charts/bunkerweb/templates/_helpers.tpl
+++ b/charts/bunkerweb/templates/_helpers.tpl
@@ -86,7 +86,11 @@ REDIS settings
 {{- define "bunkerweb.redisEnv" -}}
   {{- if .Values.redis.enabled }}
 - name: REDIS_HOST
+  {{- if .Values.settings.redis.redisHost }}
+  value: "{{ .Values.settings.redis.redisHost }}"
+  {{- else }}
   value: "redis-{{ include "bunkerweb.fullname" . }}"
+  {{- end }}
 - name: REDIS_USERNAME
   value: ""
 - name: REDIS_PASSWORD

--- a/charts/bunkerweb/templates/_helpers.tpl
+++ b/charts/bunkerweb/templates/_helpers.tpl
@@ -89,7 +89,7 @@ REDIS settings
   {{- if .Values.settings.redis.redisHost }}
   value: "{{ .Values.settings.redis.redisHost }}"
   {{- else }}
-  value: "redis-{{ include "bunkerweb.fullname" . }}"
+  value: "redis-{{ include "bunkerweb.fullname" . }}.{{ include "bunkerweb.namespace" . }}.svc.{{ .Values.settings.kubernetes.domainName }}"
   {{- end }}
 - name: REDIS_USERNAME
   value: ""

--- a/charts/bunkerweb/templates/redis-configmap.yaml
+++ b/charts/bunkerweb/templates/redis-configmap.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.redis.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config-{{ include "bunkerweb.fullname" . }}
+  namespace: {{ include "bunkerweb.namespace" . }}
+  labels:
+    {{- include "bunkerweb.labels" . | nindent 4 }}
+data:
+  redis.conf: |
+    # Basic Redis configuration for bunkerized-nginx
+    
+    # Network settings
+    bind 0.0.0.0
+    port 6379
+    protected-mode yes
+    
+    # Authentication (set your password)
+    #requirepass your-redis-password-here
+    
+    {{- if not (empty .Values.settings.existingSecret) }}
+    requirepass {{ .Values.settings.existingSecret }}
+    {{- else }}
+    requirepass {{ .Values.redis.config.password }}
+    {{- end }}
+
+    # Memory settings
+    maxmemory 512mb
+    maxmemory-policy allkeys-lru
+    
+    # Persistence settings - RDB snapshots
+    # Save snapshot if at least 1 key changed in 900 seconds
+    # Save snapshot if at least 10 keys changed in 300 seconds  
+    # Save snapshot if at least 10000 keys changed in 60 seconds
+    save 900 1
+    save 300 10
+    save 60 10000
+    
+    # RDB file settings
+    dbfilename dump.rdb
+    dir /data
+    rdbcompression yes
+    rdbchecksum yes
+    
+    # AOF (Append Only File) persistence - recommended for better durability
+    appendonly yes
+    appendfilename "appendonly.aof"
+    appendfsync everysec
+    no-appendfsync-on-rewrite no
+    auto-aof-rewrite-percentage 100
+    auto-aof-rewrite-min-size 64mb
+    
+    # Logging
+    loglevel notice
+    logfile ""
+    
+    # Client settings
+    timeout 0
+    tcp-keepalive 300
+    tcp-backlog 511
+    
+    # Database settings
+    databases 16
+    
+    # Disable dangerous commands (optional security)
+    rename-command FLUSHDB ""
+    rename-command FLUSHALL ""
+    rename-command DEBUG ""
+    
+    # Performance tuning
+    hash-max-ziplist-entries 512
+    hash-max-ziplist-value 64
+    list-max-ziplist-size -2
+    list-compress-depth 0
+    set-max-intset-entries 512
+    zset-max-ziplist-entries 128
+    zset-max-ziplist-value 64
+    
+    # Slow log settings
+    slowlog-log-slower-than 10000
+    slowlog-max-len 128
+    
+    # Client output buffer limits
+    client-output-buffer-limit normal 0 0 0
+    client-output-buffer-limit replica 256mb 64mb 60
+    client-output-buffer-limit pubsub 32mb 8mb 60
+    
+    # Disable Redis Cluster (not needed for single instance)
+    # cluster-enabled no
+    
+    # Security settings
+    protected-mode yes
+    
+    # Disable potentially dangerous commands
+    rename-command SHUTDOWN REDIS_SHUTDOWN
+    rename-command CONFIG REDIS_CONFIG
+{{- end }}

--- a/charts/bunkerweb/templates/redis-deployment.yaml
+++ b/charts/bunkerweb/templates/redis-deployment.yaml
@@ -20,20 +20,22 @@ spec:
         - name: redis
           image: redis:7-alpine
           imagePullPolicy: Always
-          command: ["redis-server"]
-          args: ["--requirepass", "$(REDIS_PASSWORD)"]
-          env:
-            - name: REDIS_PASSWORD
-              {{- if not (empty .Values.settings.existingSecret) }}
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.settings.existingSecret }}"
-                  key: redis-password
-              {{- else }}
-              value: "{{ .Values.redis.config.password }}"
-              {{- end }}
+          command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+          volumeMounts:
+          - name: redis-config
+            mountPath: /usr/local/etc/redis/
+            readOnly: true
+          - name: redis-data
+            mountPath: /data
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+      - name: redis-config
+        configMap:
+          name: redis-config-{{ include "bunkerweb.fullname" . }}
+      - name: redis-data
+        persistentVolumeClaim:
+          claimName: redis-{{ include "bunkerweb.fullname" . }}
 {{- end }}

--- a/charts/bunkerweb/templates/redis-pvc.yaml
+++ b/charts/bunkerweb/templates/redis-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.redis.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-{{ include "bunkerweb.fullname" . }}
+  namespace: {{ include "bunkerweb.namespace" . }}
+  labels:
+    {{- include "bunkerweb.labels" . | nindent 4 }}
+spec:
+  {{- if not (empty .Values.redis.persistence.storageClass) }}
+  storageClassName: "{{ .Values.redis.persistence.storageClass }}"
+  {{- end }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.redis.persistence.size }}
+{{- end }}

--- a/charts/bunkerweb/values.yaml
+++ b/charts/bunkerweb/values.yaml
@@ -137,6 +137,7 @@ ui:
   # todo : probes
 
 # Database variables
+# Enable the mariadb service to persist the installation
 mariadb:
   enabled: true
   persistence:
@@ -150,8 +151,13 @@ mariadb:
   args: []
 
 # Redis variables
+# Enable the redis service to persist the banned ips
+# Find futher information: https://docs.bunkerweb.io/latest/advanced/#persistence-of-bans-and-reports
 redis:
   enabled: true
+  persistence:
+    size: 1Gi
+    storageClass: ""
   config:
     password: "changeme"
 


### PR DESCRIPTION
I adapted the REDIS_HOST default domain to it's service full domain name `<service-name>.<ns>.svc.<cluster-domain>`, because in some clusters only stating the service name can lead to a non resolvable error (which is my case).