### PR TITLE
fix(bwapi): expose port 5000

### DIFF
--- a/charts/bunkerweb/templates/bunkerweb-deployment.yaml
+++ b/charts/bunkerweb/templates/bunkerweb-deployment.yaml
@@ -66,6 +66,8 @@ spec:
             {{- toYaml . | nindent 12}}
           {{- end }}
           ports:
+            - containerPort: 5000
+              name: bwapi
             - containerPort: 8080
             - containerPort: 8443
             - containerPort: 9113

--- a/charts/bunkerweb/templates/bunkerweb-service-internal.yaml
+++ b/charts/bunkerweb/templates/bunkerweb-service-internal.yaml
@@ -6,10 +6,14 @@ metadata:
   labels:
     {{- include "bunkerweb.labels" . | nindent 4 }}
 spec:
-  clusterIP: None
+  type: ClusterIP
   selector:
     bunkerweb.io/component: "bunkerweb"
-
+  ports:
+    - name: bwapi
+      protocol: TCP
+      port: 5000
+      targetPort: 5000
 ---
 
 apiVersion: v1


### PR DESCRIPTION
The scheduler had no access to the bwapi port running in the bunkerweb container. As suggested on discord I've exposed the port on the bunkerweb-internal port which yielded a reachable instance.