### PR TITLE
fix: add BUNKERWEB_NAMESPACE environment variable

### DIFF
--- a/charts/bunkerweb/templates/controller-deployment.yaml
+++ b/charts/bunkerweb/templates/controller-deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: "{{ .Values.settings.kubernetes.ignoreAnnotations }}"
             - name: BUNKERWEB_SERVICE_NAME
               value: "{{ include "bunkerweb.fullname" . }}-external"
+            - name: BUNKERWEB_NAMESPACE
+              value: "{{ include "bunkerweb.namespace" . }}"
             {{- if .Values.controller.extraEnvs }}
             {{- toYaml .Values.controller.extraEnvs | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
add BUNKERWEB_NAMESPACE environment variable to controller deployment to allow it running in another namespace than the default 'bunkerweb' namespace.